### PR TITLE
Fix tests and session auth

### DIFF
--- a/intgtest/README.md
+++ b/intgtest/README.md
@@ -30,7 +30,7 @@ in `~/.vantiq/profile`.
 Once the project has been loaded, the integration tests can be run using the
 command line:
 
-    % env SERVER=<VantiqServerUrl> AUTHTOKEN=<VantiqAccessToken> mocha intgSpec.js --exit
+    % env SERVER=<VantiqServerUrl> AUTHTOKEN=<VantiqAccessToken> mocha intgSpec.js
 
 *   **NOTE:** If an error occurs such as: `"env: mocha: No such file or directory"`, use
     `` `npm bin`/mocha `` instead of `mocha`.

--- a/intgtest/README.md
+++ b/intgtest/README.md
@@ -32,5 +32,5 @@ command line:
 
     % env SERVER=<VantiqServerUrl> AUTHTOKEN=<VantiqAccessToken> mocha intgSpec.js --exit
 
-*   **NOTE:** If an error occurs such as: `"env: mocha: No such file or directory"`, simply place
-    `` `npm bin`/ `` before `mocha`.
+*   **NOTE:** If an error occurs such as: `"env: mocha: No such file or directory"`, use
+    `` `npm bin`/mocha `` instead of `mocha`.

--- a/intgtest/intgSpec.js
+++ b/intgtest/intgSpec.js
@@ -44,6 +44,10 @@ describe('Vantiq SDK Integration Tests', function() {
         return v.session.accessToken = AUTHTOKEN;
     });
 
+    after(function() {
+        v.unsubscribeAll()
+    });
+
     it('can select data with no constraints', function() {
         return v.select('system.types')
             .then((result) => {

--- a/intgtest/intgSpec.js
+++ b/intgtest/intgSpec.js
@@ -272,10 +272,10 @@ describe('Vantiq SDK Integration Tests', function() {
                 // Rule should insert the record into a TestType
                 // so select it to find the record.  However, this
                 // takes some time to execute the rule, so we need
-                // to give it some time.  Adding 2 seconds, in case
+                // to give it some time.  Adding 1.5 seconds, in case
                 // it restarted and needs to generate the rule.
                 return new Promise((resolve, reject) => {
-                    setTimeout(() => resolve(), 1000);
+                    setTimeout(() => resolve(), 1500);
                 })
                 .then(() => {
                     return v.select('TestType', [], { id: id });

--- a/intgtest/project/rules/onTestPublish.vail
+++ b/intgtest/project/rules/onTestPublish.vail
@@ -3,3 +3,4 @@ RULE onTestPublish
 WHEN PUBLISH OCCURS ON "/test/topic" AS event
 
 INSERT INTO TestType(event.newValue)
+Event.ack()

--- a/lib/subscriber.js
+++ b/lib/subscriber.js
@@ -51,7 +51,7 @@ VantiqSubscriber.prototype.connect = function() {
             // provided session access token to create an authenticated WS session.
             var auth = {
                 op:           'validate',
-                resourceName: 'users',
+                resourceName: 'system.credentials',
                 object:       this.session.accessToken
             };
             this.sock.send(JSON.stringify(auth));


### PR DESCRIPTION
When `session.js` tried to auth with a token it was sending to `users` instead of `system.credentials`. This was causing failures in several tests.

A few timing issues were addressed.

