### PR TITLE
Move to oldest supported version of node js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 node_js:
   - "node"
+  - "13"
+  - "12"
   - "10"
-  - "6"
 
 # safelist
 branches:

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "email": "support@vantiq.com"
   },
   "engines": {
-    "node": ">= 6.0.0"
+    "node": ">= 10.0.0"
   },
   "homepage": "http://vantiq.com/",
   "license": "MIT"


### PR DESCRIPTION
Node versions 6 and 8 are well past end of life, so this updates to the current oldest (still supported) version of node JS (v10).

This should get the travis build to pass, the only issues were when testing against node version 6 (which was deprecated back in 2018 I believe).

